### PR TITLE
Removed aligment span in uncrustify.conf, manual format cleanup.

### DIFF
--- a/common/rfm.h
+++ b/common/rfm.h
@@ -527,12 +527,12 @@ uint16_t rfm_spi16(uint16_t outval);
 
 #define RFM_FRAME_MAX 80
 
-typedef enum { rfmmode_stop	= 0,
+typedef enum { rfmmode_stop     = 0,
 	       rfmmode_start_tx = 1,
-	       rfmmode_tx	= 2,
-	       rfmmode_tx_done	= 3,
-	       rfmmode_rx	= 4,
-	       rfmmode_rx_owf	= 5, } rfm_mode_t;
+	       rfmmode_tx       = 2,
+	       rfmmode_tx_done  = 3,
+	       rfmmode_rx       = 4,
+	       rfmmode_rx_owf   = 5, } rfm_mode_t;
 
 extern uint8_t rfm_framebuf[RFM_FRAME_MAX];
 extern uint8_t rfm_framesize;

--- a/rfm-master/eeprom.h
+++ b/rfm-master/eeprom.h
@@ -45,11 +45,12 @@
 #define EEPROM __attribute__((section(".eeprom")))
 
 typedef struct                                          // each variables must be uint8_t or int8_t without exception
-{ #if (RFM == 1)
-	/* 00...07 */uint8_t security_key[8];           //!< key for encrypted radio messasges
+{
+ #if (RFM == 1)
+	/* 00...07 */ uint8_t security_key[8];          //!< key for encrypted radio messasges
 #if (RFM_TUNING > 0)
-	/* 08 */int8_t RFM_freqAdjust;                  //!< RFM12 Frequency adjustment
-	/* 09 */uint8_t RFM_tuning;                     //!< RFM12 tuning mode
+	/*      08 */ int8_t RFM_freqAdjust;            //!< RFM12 Frequency adjustment
+	/*      09 */ uint8_t RFM_tuning;               //!< RFM12 tuning mode
 #endif
 #endif
 } config_t;
@@ -93,19 +94,19 @@ uint8_t EEPROM ee_reserved2_60 [60] = {
 
 uint8_t EEPROM ee_config[][4] = {  // must be alligned to 4 bytes
 // order on this table depend to config_t
-// /*idx*/ {value,  default,    min,    max},
+//      /*idx*/  {          value,         default,   min,  max },
 #if (RFM == 1)
-	/* 00 */ { SECURITY_KEY_0,  SECURITY_KEY_0,  0x00,		 0xff },        //!< security_key[0] for encrypted radio messasges
-	/* 01 */ { SECURITY_KEY_1,  SECURITY_KEY_1,  0x00,		 0xff },        //!< security_key[1] for encrypted radio messasges
-	/* 02 */ { SECURITY_KEY_2,  SECURITY_KEY_2,  0x00,		 0xff },        //!< security_key[2] for encrypted radio messasges
-	/* 03 */ { SECURITY_KEY_3,  SECURITY_KEY_3,  0x00,		 0xff },        //!< security_key[3] for encrypted radio messasges
-	/* 04 */ { SECURITY_KEY_4,  SECURITY_KEY_4,  0x00,		 0xff },        //!< security_key[4] for encrypted radio messasges
-	/* 05 */ { SECURITY_KEY_5,  SECURITY_KEY_5,  0x00,		 0xff },        //!< security_key[5] for encrypted radio messasges
-	/* 06 */ { SECURITY_KEY_6,  SECURITY_KEY_6,  0x00,		 0xff },        //!< security_key[6] for encrypted radio messasges
-	/* 07 */ { SECURITY_KEY_7,  SECURITY_KEY_7,  0x00,		 0xff },        //!< security_key[7] for encrypted radio messasges
+	/* 00 */ { SECURITY_KEY_0,  SECURITY_KEY_0,  0x00, 0xff },              //!< security_key[0] for encrypted radio messasges
+	/* 01 */ { SECURITY_KEY_1,  SECURITY_KEY_1,  0x00, 0xff },              //!< security_key[1] for encrypted radio messasges
+	/* 02 */ { SECURITY_KEY_2,  SECURITY_KEY_2,  0x00, 0xff },              //!< security_key[2] for encrypted radio messasges
+	/* 03 */ { SECURITY_KEY_3,  SECURITY_KEY_3,  0x00, 0xff },              //!< security_key[3] for encrypted radio messasges
+	/* 04 */ { SECURITY_KEY_4,  SECURITY_KEY_4,  0x00, 0xff },              //!< security_key[4] for encrypted radio messasges
+	/* 05 */ { SECURITY_KEY_5,  SECURITY_KEY_5,  0x00, 0xff },              //!< security_key[5] for encrypted radio messasges
+	/* 06 */ { SECURITY_KEY_6,  SECURITY_KEY_6,  0x00, 0xff },              //!< security_key[6] for encrypted radio messasges
+	/* 07 */ { SECURITY_KEY_7,  SECURITY_KEY_7,  0x00, 0xff },              //!< security_key[7] for encrypted radio messasges
 #if (RFM_TUNING > 0)
-	/*    */ { 0,		    0,		     0x00,		 0xff },        //!< RFM12 Frequency adjustment, 2's complement
-	/*    */ { RFM_TUNING_MODE, RFM_TUNING_MODE, 0x00,		 0xff },        //!< RFM12 tuning mode, 0 = tuning mode off (narrow, high data rate), 1 = tuning mode on (wide, low data rate)
+	/*    */ {              0,               0,  0x00, 0xff },              //!< RFM12 Frequency adjustment, 2's complement
+	/*    */ { RFM_TUNING_MODE, RFM_TUNING_MODE, 0x00, 0xff },              //!< RFM12 tuning mode, 0 = tuning mode off (narrow, high data rate), 1 = tuning mode on (wide, low data rate)
 #endif
 
 #endif

--- a/src/eeprom.h
+++ b/src/eeprom.h
@@ -48,78 +48,79 @@
 #define EEPROM __attribute__((section(".eeprom")))
 
 typedef struct                                                  // each variables must be uint8_t or int8_t without exception
-{ /* 00 */ uint8_t lcd_contrast;
-	   /* 01 */ uint8_t temperature0;                       //!< temperature 0  - frost protection (unit is 0.5stC)
-	   /* 02 */ uint8_t temperature1;                       //!< temperature 1  - energy save (unit is 0.5stC)
-	   /* 03 */ uint8_t temperature2;                       //!< temperature 2  - comfort (unit is 0.5stC)
-	   /* 04 */ uint8_t temperature3;                       //!< temperature 3  - supercomfort (unit is 0.5stC)
-	   /* 05 */ uint8_t P3_Factor;                          //!< Proportional cubic tuning constant
-	   /* 06 */ uint8_t P_Factor;                           //!< Proportional tuning constant
-	   /* 07 */ uint8_t I_Factor;                           //!< Integral tuning constant
-	   /* 08 */ uint8_t I_max_credit;                       //!< credit for interator limitation
-	   /* 09 */ uint8_t I_credit_expiration;                //!< unit is PID_interval
-	   /* 0a */ uint8_t PID_interval;                       //!< PID_interval*5 = interval in seconds
-	   /* 0b */ uint8_t valve_min;                          //!< valve position limiter min
-	   /* 0c */ uint8_t valve_center;                       //!< default valve position for "zero - error" - improve stabilization after change temperature
-	   /* 0d */ uint8_t valve_max;                          //!< valve position limiter max
-	   /* 0e */ uint8_t valve_hysteresis;                   //!< valve movement hysteresis (unit is 1/128%)
-	   /* 0f */ uint8_t motor_pwm_min;                      //!< min PWM for motor
-	   /* 10 */ uint8_t motor_pwm_max;                      //!< max PWM for motor
-	   /* 11 */ uint8_t motor_eye_low;                      //!< min signal lenght to accept low level (multiplied by 2)
-	   /* 12 */ uint8_t motor_eye_high;                     //!< min signal lenght to accept high level (multiplied by 2)
-	   /* 13 */ uint8_t motor_close_eye_timeout;            //!<time from last pulse to disable eye [1/61sec]
-	   /* 14 */ uint8_t motor_end_detect_cal;               //!< stop timer threshold in % to previous average
-	   /* 15 */ uint8_t motor_end_detect_run;               //!< stop timer threshold in % to previous average
-	   /* 16 */ uint8_t motor_speed;                        //!< /8
-	   /* 17 */ uint8_t motor_speed_ctl_gain;
-	   /* 18 */ uint8_t motor_pwm_max_step;
-	   /* 19 */ uint8_t MOTOR_ManuCalibration_L;
-	   /* 1a */ uint8_t MOTOR_ManuCalibration_H;
-	   /* 1b */ uint8_t temp_cal_table0;            //!< temperature calibration table
-	   /* 1c */ uint8_t temp_cal_table1;            //!< temperature calibration table
-	   /* 1d */ uint8_t temp_cal_table2;            //!< temperature calibration table
-	   /* 1e */ uint8_t temp_cal_table3;            //!< temperature calibration table
-	   /* 1f */ uint8_t temp_cal_table4;            //!< temperature calibration table
-	   /* 20 */ uint8_t temp_cal_table5;            //!< temperature calibration table
-	   /* 21 */ uint8_t temp_cal_table6;            //!< temperature calibration table
-	   /* 22 */ uint8_t timer_mode;                 //!< bit0: timermode; =0 only one program, =1 programs for weekdays
-	   // >1 manual mode, the higher bits contain the saved temperature << 1
+{
+	/* 00 */ uint8_t lcd_contrast;
+	/* 01 */ uint8_t temperature0;                          //!< temperature 0  - frost protection (unit is 0.5stC)
+	/* 02 */ uint8_t temperature1;                          //!< temperature 1  - energy save (unit is 0.5stC)
+	/* 03 */ uint8_t temperature2;                          //!< temperature 2  - comfort (unit is 0.5stC)
+	/* 04 */ uint8_t temperature3;                          //!< temperature 3  - supercomfort (unit is 0.5stC)
+	/* 05 */ uint8_t P3_Factor;                             //!< Proportional cubic tuning constant
+	/* 06 */ uint8_t P_Factor;                              //!< Proportional tuning constant
+	/* 07 */ uint8_t I_Factor;                              //!< Integral tuning constant
+	/* 08 */ uint8_t I_max_credit;                          //!< credit for interator limitation
+	/* 09 */ uint8_t I_credit_expiration;                   //!< unit is PID_interval
+	/* 0a */ uint8_t PID_interval;                          //!< PID_interval*5 = interval in seconds
+	/* 0b */ uint8_t valve_min;                             //!< valve position limiter min
+	/* 0c */ uint8_t valve_center;                          //!< default valve position for "zero - error" - improve stabilization after change temperature
+	/* 0d */ uint8_t valve_max;                             //!< valve position limiter max
+	/* 0e */ uint8_t valve_hysteresis;                      //!< valve movement hysteresis (unit is 1/128%)
+	/* 0f */ uint8_t motor_pwm_min;                         //!< min PWM for motor
+	/* 10 */ uint8_t motor_pwm_max;                         //!< max PWM for motor
+	/* 11 */ uint8_t motor_eye_low;                         //!< min signal lenght to accept low level (multiplied by 2)
+	/* 12 */ uint8_t motor_eye_high;                        //!< min signal lenght to accept high level (multiplied by 2)
+	/* 13 */ uint8_t motor_close_eye_timeout;               //!<time from last pulse to disable eye [1/61sec]
+	/* 14 */ uint8_t motor_end_detect_cal;                  //!< stop timer threshold in % to previous average
+	/* 15 */ uint8_t motor_end_detect_run;                  //!< stop timer threshold in % to previous average
+	/* 16 */ uint8_t motor_speed;                           //!< /8
+	/* 17 */ uint8_t motor_speed_ctl_gain;
+	/* 18 */ uint8_t motor_pwm_max_step;
+	/* 19 */ uint8_t MOTOR_ManuCalibration_L;
+	/* 1a */ uint8_t MOTOR_ManuCalibration_H;
+	/* 1b */ uint8_t temp_cal_table0;                       //!< temperature calibration table
+	/* 1c */ uint8_t temp_cal_table1;                       //!< temperature calibration table
+	/* 1d */ uint8_t temp_cal_table2;                       //!< temperature calibration table
+	/* 1e */ uint8_t temp_cal_table3;                       //!< temperature calibration table
+	/* 1f */ uint8_t temp_cal_table4;                       //!< temperature calibration table
+	/* 20 */ uint8_t temp_cal_table5;                       //!< temperature calibration table
+	/* 21 */ uint8_t temp_cal_table6;                       //!< temperature calibration table
+	/* 22 */ uint8_t timer_mode;                            //!< bit0: timermode; =0 only one program, =1 programs for weekdays
+	//                                                                            >1 manual mode, the higher bits contain the saved temperature << 1
 #if HR25
-	   /*    */ uint8_t bat_half_thld;              //!< treshold for half battery indicator [unit 0.02V]=[unit 0.01V per cell]
+	/*    */ uint8_t bat_half_thld;                         //!< treshold for half battery indicator [unit 0.02V]=[unit 0.01V per cell]
 #endif
-	   /*    */ uint8_t bat_warning_thld;           //!< treshold for battery warning [unit 0.02V]=[unit 0.01V per cell]
-	   /*    */ uint8_t bat_low_thld;               //!< threshold for battery low [unit 0.02V]=[unit 0.01V per cell]
-	   /*    */ uint8_t allow_ADC_during_motor;
+	/*    */ uint8_t bat_warning_thld;                      //!< treshold for battery warning [unit 0.02V]=[unit 0.01V per cell]
+	/*    */ uint8_t bat_low_thld;                          //!< threshold for battery low [unit 0.02V]=[unit 0.01V per cell]
+	/*    */ uint8_t allow_ADC_during_motor;
 #if HW_WINDOW_DETECTION
-	   /*    */ uint8_t window_open_detection_enable;
-	   /*    */ uint8_t window_open_detection_delay;        //!< window open detection delay [sec]
-	   /*    */ uint8_t window_close_detection_delay;       //!< window close detection delay [sec]
+	/*    */ uint8_t window_open_detection_enable;
+	/*    */ uint8_t window_open_detection_delay;           //!< window open detection delay [sec]
+	/*    */ uint8_t window_close_detection_delay;          //!< window close detection delay [sec]
 #else
-	   /*    */ uint8_t window_open_detection_diff;         //!< threshold for window open detection unit is 0.1C
-	   /*    */ uint8_t window_close_detection_diff;        //!< threshold for window close detection unit is 0.1C
-	   /*    */ uint8_t window_open_detection_time;
-	   /*    */ uint8_t window_close_detection_time;
-	   /*    */ uint8_t window_open_timeout;     //!< maximum time for window open state [minutes]
+	/*    */ uint8_t window_open_detection_diff;            //!< threshold for window open detection unit is 0.1C
+	/*    */ uint8_t window_close_detection_diff;           //!< threshold for window close detection unit is 0.1C
+	/*    */ uint8_t window_open_detection_time;
+	/*    */ uint8_t window_close_detection_time;
+	/*    */ uint8_t window_open_timeout;                   //!< maximum time for window open state [minutes]
 #endif
 #if BOOST_CONTROLER_AFTER_CHANGE
-	   /*    */ uint8_t temp_boost_setpoint_diff;
-	   /*    */ uint8_t temp_boost_hystereses;
-	   /*    */ uint8_t temp_boost_error;
-	   /*    */ uint8_t temp_boost_tempchange;
-	   /*    */ uint8_t temp_boost_time_cool;
-	   /*    */ uint8_t temp_boost_time_heat;
+	/*    */ uint8_t temp_boost_setpoint_diff;
+	/*    */ uint8_t temp_boost_hystereses;
+	/*    */ uint8_t temp_boost_error;
+	/*    */ uint8_t temp_boost_tempchange;
+	/*    */ uint8_t temp_boost_time_cool;
+	/*    */ uint8_t temp_boost_time_heat;
 #endif
 #if TEMP_COMPENSATE_OPTION
-	   /*    */ int8_t room_temp_offset;
+	/*    */ int8_t room_temp_offset;
 #endif
 #if (RFM == 1)
-	   /*    */ uint8_t RFM_devaddr;                //!< HR20's own device address in RFM radio networking. =0 mean disable radio
-	   /*    */ uint8_t security_key[8];            //!< key for encrypted radio messasges
+	/*    */ uint8_t RFM_devaddr;                           //!< HR20's own device address in RFM radio networking. =0 mean disable radio
+	/*    */ uint8_t security_key[8];                       //!< key for encrypted radio messasges
 #if (RFM_TUNING > 0)
-	   /*    */ int8_t RFM_freqAdjust;              //!< RFM12 Frequency adjustment
-	   /*    */ uint8_t RFM_tuning;                 //!< RFM12 tuning mode
+	/*    */ int8_t RFM_freqAdjust;                         //!< RFM12 Frequency adjustment
+	/*    */ uint8_t RFM_tuning;                            //!< RFM12 tuning mode
 #endif
-	   /* unused */
+	/* unused */
 #endif
 } config_t;
 
@@ -197,95 +198,96 @@ uint8_t EEPROM ee_reserved2_60 [60] = {
 
 uint8_t EEPROM ee_config[][4] = {       // must be alligned to 4 bytes
 // order on this table depend to config_t
-// /*idx*/ {value,  default,    min,    max},
-	/* 00 */ { 14,			  14,			 0,			      15			       },       //!< lcd_contrast  (unit 0.5stC)
-	/* 01 */ { 10,			  10,			 TEMP_MIN,		      TEMP_MAX			       },       //!< temperature 0  - frost protection (unit is 0.5stC)
-	/* 02 */ { 34,			  34,			 TEMP_MIN,		      TEMP_MAX			       },       //!< temperature 1  - energy save (unit is 0.5stC)
-	/* 03 */ { 42,			  42,			 TEMP_MIN,		      TEMP_MAX			       },       //!< temperature 2  - comfort (unit is 0.5stC)
-	/* 04 */ { 48,			  48,			 TEMP_MIN,		      TEMP_MAX			       },       //!< temperature 3  - supercomfort (unit is 0.5stC)
-	/* 05 */ { 33,			  33,			 0,			      255			       },       //!< P3_Factor;
-	/* 06 */ { 8,			  8,			 0,			      255			       },       //!< P_Factor;
-	/* 07 */ { 32,			  32,			 0,			      255			       },       //!< I_Factor;
-	/* 08 */ { 40,			  40,			 0,			      127			       },       //!< I_max_credit
-	/* 09 */ { 30,			  30,			 0,			      255			       },       //!< I_credit_expiration unit is PID_interval, default 2 hour
-	/* 0a */ { 240 / 5,		  240 / 5,		 20 / 5,		      255			       },       //!< PID_interval*5 = interval in seconds;  min=20sec, max=21.25 minutes
-	/* 0b */ { 30,			  30,			 0,			      100			       },       //!< valve_min
-	/* 0c */ { 45,			  45,			 0,			      100			       },       //!< valve_center
-	/* 0d */ { 80,			  80,			 0,			      100			       },       //!< valve_max
-	/* 0e */ { 64,			  64,			 0,			      127			       },       //!< valve_hysteresis; valve movement hysteresis (unit is 1/128%), must be <128
-	/* 0f */ { 32,			  32,			 32,			      255			       },       //!< min motor_pwm PWM setting
-	/* 10 */ { 250,			  250,			 50,			      255			       },       //!< max motor_pwm PWM setting
-	/* 11 */ { 100,			  100,			 1,			      255			       },       //!< motor_eye_low
-	/* 12 */ { 25,			  25,			 1,			      255			       },       //!< motor_eye_high
-	/* 13 */ { 78,			  78,			 5,			      255			       },       //!< motor_close_eye_timeout; time from last pulse to disable eye [1/61sec]
-	/* 14 */ { 130,			  130,			 110,			      250			       },       //!< motor_end_detect_cal; stop timer threshold in % to previous average
-	/* 15 */ { 150,			  150,			 110,			      250			       },       //!< motor_end_detect_run; stop timer threshold in % to previous average
-	/* 16 */ { 184,			  184,			 10,			      255			       },       //!< motor_speed
-	/* 17 */ { 50,			  50,			 10,			      200			       },       //!< motor_speed_ctl_gain
-	/* 18 */ { 10,			  10,			 1,			      64			       },       //!< motor_pwm_max_step
-	/* 19 */ { 255,			  255,			 0,			      255			       },       //!< manual calibration L
-	/* 1a */ { 255,			  255,			 0,			      255			       },       //!< manual calibration H
+//      /*idx */ {                 value,               default,      min,                        max},
+	/* 00 */ {                    14,                    14,        0,                        15 }, //!< lcd_contrast  (unit 0.5stC)
+	/* 01 */ {                    10,                    10, TEMP_MIN,                  TEMP_MAX }, //!< temperature 0  - frost protection (unit is 0.5stC)
+	/* 02 */ {                    34,                    34, TEMP_MIN,                  TEMP_MAX }, //!< temperature 1  - energy save (unit is 0.5stC)
+	/* 03 */ {                    42,                    42, TEMP_MIN,                  TEMP_MAX }, //!< temperature 2  - comfort (unit is 0.5stC)
+	/* 04 */ {                    48,                    48, TEMP_MIN,                  TEMP_MAX }, //!< temperature 3  - supercomfort (unit is 0.5stC)
+	/* 05 */ {                    33,                    33,        0,                       255 }, //!< P3_Factor;
+	/* 06 */ {                     8,                     8,        0,                       255 }, //!< P_Factor;
+	/* 07 */ {                    32,                    32,        0,                       255 }, //!< I_Factor;
+	/* 08 */ {                    40,                    40,        0,                       127 }, //!< I_max_credit
+	/* 09 */ {                    30,                    30,        0,                       255 }, //!< I_credit_expiration unit is PID_interval, default 2 hour
+	/* 0a */ {               240 / 5,               240 / 5,   20 / 5,                       255 }, //!< PID_interval*5 = interval in seconds;  min=20sec, max=21.25 minutes
+	/* 0b */ {                    30,                    30,        0,                       100 }, //!< valve_min
+	/* 0c */ {                    45,                    45,        0,                       100 }, //!< valve_center
+	/* 0d */ {                    80,                    80,        0,                       100 }, //!< valve_max
+	/* 0e */ {                    64,                    64,        0,                       127 }, //!< valve_hysteresis; valve movement hysteresis (unit is 1/128%), must be <128
+	/* 0f */ {                    32,                    32,       32,                       255 }, //!< min motor_pwm PWM setting
+	/* 10 */ {                   250,                   250,       50,                       255 }, //!< max motor_pwm PWM setting
+	/* 11 */ {                   100,                   100,        1,                       255 }, //!< motor_eye_low
+	/* 12 */ {                    25,                    25,        1,                       255 }, //!< motor_eye_high
+	/* 13 */ {                    78,                    78,        5,                       255 }, //!< motor_close_eye_timeout; time from last pulse to disable eye [1/61sec]
+	/* 14 */ {                   130,                   130,      110,                       250 }, //!< motor_end_detect_cal; stop timer threshold in % to previous average
+	/* 15 */ {                   150,                   150,      110,                       250 }, //!< motor_end_detect_run; stop timer threshold in % to previous average
+	/* 16 */ {                   184,                   184,       10,                       255 }, //!< motor_speed
+	/* 17 */ {                    50,                    50,       10,                       200 }, //!< motor_speed_ctl_gain
+	/* 18 */ {                    10,                    10,        1,                        64 }, //!< motor_pwm_max_step
+	/* 19 */ {                   255,                   255,        0,                       255 }, //!< manual calibration L
+	/* 1a */ {                   255,                   255,        0,                       255 }, //!< manual calibration H
 #if THERMOTRONIC == 1
-	/* 1b */ { 605 - TEMP_CAL_OFFSET, 605 - TEMP_CAL_OFFSET, 0,			      255			       },       //!< value for 35C => 605 temperature calibration table
-	/* 1c */ { 645 - 605,		  645 - 605,		 16,			      255			       },       //!< value for 30C => 645 temperature calibration table
-	/* 1d */ { 685 - 645,		  685 - 645,		 16,			      255			       },       //!< value for 25C => 685 temperature calibration table
-	/* 1e */ { 825 - 685,		  825 - 685,		 16,			      255			       },       //!< value for 20C => 825 temperature calibration table
-	/* 1f */ { 865 - 825,		  865 - 825,		 16,			      255			       },       //!< value for 15C => 865 temperature calibration table
-	/* 20 */ { 905 - 865,		  905 - 865,		 16,			      255			       },       //!< value for 10C => 905 temperature calibration table
-	/* 21 */ { 945 - 905,		  945 - 905,		 16,			      255			       },       //!< value for 05C => 945 temperature calibration table
+	/* 1b */ { 605 - TEMP_CAL_OFFSET, 605 - TEMP_CAL_OFFSET,        0,                       255 }, //!< value for 35C => 605 temperature calibration table
+	/* 1c */ {             645 - 605,             645 - 605,       16,                       255 }, //!< value for 30C => 645 temperature calibration table
+	/* 1d */ {             685 - 645,             685 - 645,       16,                       255 }, //!< value for 25C => 685 temperature calibration table
+	/* 1e */ {             825 - 685,             825 - 685,       16,                       255 }, //!< value for 20C => 825 temperature calibration table
+	/* 1f */ {             865 - 825,             865 - 825,       16,                       255 }, //!< value for 15C => 865 temperature calibration table
+	/* 20 */ {             905 - 865,             905 - 865,       16,                       255 }, //!< value for 10C => 905 temperature calibration table
+	/* 21 */ {             945 - 905,             945 - 905,       16,                       255 }, //!< value for 05C => 945 temperature calibration table
 #else
-	/* 1b */ { 295 - TEMP_CAL_OFFSET, 295 - TEMP_CAL_OFFSET, 0,			      255			       },       //!< value for 35C => 295 temperature calibration table
-	/* 1c */ { 340 - 295,		  340 - 295,		 16,			      255			       },       //!< value for 30C => 340 temperature calibration table
-	/* 1d */ { 397 - 340,		  397 - 340,		 16,			      255			       },       //!< value for 25C => 397 temperature calibration table
-	/* 1e */ { 472 - 397,		  472 - 397,		 16,			      255			       },       //!< value for 20C => 472 temperature calibration table
-	/* 1f */ { 549 - 472,		  549 - 472,		 16,			      255			       },       //!< value for 15C => 549 temperature calibration table
-	/* 20 */ { 614 - 549,		  614 - 549,		 16,			      255			       },       //!< value for 10C => 614 temperature calibration table
-	/* 21 */ { 675 - 614,		  675 - 614,		 16,			      255			       },       //!< value for 05C => 675 temperature calibration table
+	/* 1b */ { 295 - TEMP_CAL_OFFSET, 295 - TEMP_CAL_OFFSET,        0,                       255 }, //!< value for 35C => 295 temperature calibration table
+	/* 1c */ {             340 - 295,             340 - 295,       16,                       255 }, //!< value for 30C => 340 temperature calibration table
+	/* 1d */ {             397 - 340,             397 - 340,       16,                       255 }, //!< value for 25C => 397 temperature calibration table
+	/* 1e */ {             472 - 397,             472 - 397,       16,                       255 }, //!< value for 20C => 472 temperature calibration table
+	/* 1f */ {             549 - 472,             549 - 472,       16,                       255 }, //!< value for 15C => 549 temperature calibration table
+	/* 20 */ {             614 - 549,             614 - 549,       16,                       255 }, //!< value for 10C => 614 temperature calibration table
+	/* 21 */ {             675 - 614,             675 - 614,       16,                       255 }, //!< value for 05C => 675 temperature calibration table
 #endif
-	/* 22 */ { 0,			  0,			 0,			      ((TEMP_MAX + 1) << 1) + 1	       },       //!< bit0: timer_mode; =0 only one program, =1 programs for weekdays
-	// >1 manual mode, the higher bits contain the saved temperature << 1
+	/* 22 */ {                     0,                     0,        0, ((TEMP_MAX + 1) << 1) + 1 }, //!< bit0: timer_mode; =0 only one program, =1 programs for weekdays
+	//                                                                                                                     >1 manual mode, the higher bits contain the saved temperature << 1
 #if HR25
-	/*    */ { 125,			  125,			 80,			      160			       },       //!< bat_half_thld; treshold for half battery indicator [unit 0.02V]=[unit 0.01V per cell]
+	/*    */ {                   125,                   125,       80,                       160 }, //!< bat_half_thld; treshold for half battery indicator [unit 0.02V]=[unit 0.01V per cell]
 #endif
-	/*    */ { 120,			  120,			 80,			      160			       },       //!< bat_warning_thld; treshold for battery warning [unit 0.02V]=[unit 0.01V per cell]
-	/*    */ { 100,			  100,			 80,			      160			       },       //!< bat_low_thld; treshold for battery low [unit 0.02V]=[unit 0.01V per cell]
-	/*    */ { 1,			  1,			 0,			      1				       },       //!< allow_ADC_during_motor
+	/*    */ {                   120,                   120,       80,                       160 }, //!< bat_warning_thld; treshold for battery warning [unit 0.02V]=[unit 0.01V per cell]
+	/*    */ {                   100,                   100,       80,                       160 }, //!< bat_low_thld; treshold for battery low [unit 0.02V]=[unit 0.01V per cell]
+	/*    */ {                     1,                     1,        0,                         1 }, //!< allow_ADC_during_motor
 #if HW_WINDOW_DETECTION
-	/*    */ { 1,			  1,			 0,			      1				       },       //!< window_open_detection_enable
-	/*    */ { 5,			  5,			 0,			      240			       },       //!< window_open_detection_delay [sec] max 4 minutes
-	/*    */ { 5,			  5,			 0,			      240			       },       //!< window_close_detection_delay [sec] max 4 minutes
+	/*    */ {                     1,                     1,        0,                         1 }, //!< window_open_detection_enable
+	/*    */ {                     5,                     5,        0,                       240 }, //!< window_open_detection_delay [sec] max 4 minutes
+	/*    */ {                     5,                     5,        0,                       240 }, //!< window_close_detection_delay [sec] max 4 minutes
 #else
-	/*    */ { 50,			  50,			 7,			      255			       },       //!< window_open_detection_diff; reshold for window open/close detection unit is 0.01C
-	/*    */ { 50,			  50,			 7,			      255			       },       //!< window_close_detection_diff; reshold for window open/close detection unit is 0.01C
-	/*    */ { 8,			  8,			 1,			      AVGS_BUFFER_LEN		       },       //!< window_open_detection_time unit 15sec = 1/4min
-	/*    */ { 8,			  8,			 1,			      AVGS_BUFFER_LEN		       },       //!< window_close_detection_time unit 15sec = 1/4min
-	/*    */ { 90,			  90,			 2,			      255			       },       //!< window_open_timeout
+	/*    */ {                    50,                    50,        7,                       255 }, //!< window_open_detection_diff; reshold for window open/close detection unit is 0.01C
+	/*    */ {                    50,                    50,        7,                       255 }, //!< window_close_detection_diff; reshold for window open/close detection unit is 0.01C
+	/*    */ {                     8,                     8,        1,           AVGS_BUFFER_LEN }, //!< window_open_detection_time unit 15sec = 1/4min
+	/*    */ {                     8,                     8,        1,           AVGS_BUFFER_LEN }, //!< window_close_detection_time unit 15sec = 1/4min
+	/*    */ {                    90,                    90,        2,                       255 }, //!< window_open_timeout
 #endif
 #if BOOST_CONTROLER_AFTER_CHANGE
-	/*    */ { 50,			  0,			 0,			      255			       },       //!< temp_boost_setpoint_diff, unit 0,01°C
-	/*    */ { 10,			  0,			 0,			      255			       },       //!< temp_boost_hystereses, unit 0,01°C
-	/*    */ { 30,			  0,			 0,			      255			       },       //!< temp_boost_error, unit 0,01°C
-	/*    */ { 5,			  0,			 0,			      255			       },       //!< temp_boost_tempchange_heat,0,1°C, boosttime=error/10(0,1°C)*time/tempchange
-	/*    */ { 64,			  0,			 0,			      255			       },       //!< temp_boost_time_cool, minutes
-	/*    */ { 15,			  0,			 0,			      255			       },       //!< temp_boost_time_heat, minutes
+	/*    */ {                    50,                     0,        0,                       255 }, //!< temp_boost_setpoint_diff, unit 0,01°C
+	/*    */ {                    10,                     0,        0,                       255 }, //!< temp_boost_hystereses, unit 0,01°C
+	/*    */ {                    30,                     0,        0,                       255 }, //!< temp_boost_error, unit 0,01°C
+	/*    */ {                     5,                     0,        0,                       255 }, //!< temp_boost_tempchange_heat,0,1°C, boosttime=error/10(0,1°C)*time/tempchange
+	/*    */ {                    64,                     0,        0,                       255 }, //!< temp_boost_time_cool, minutes
+	/*    */ {                    15,                     0,        0,                       255 }, //!< temp_boost_time_heat, minutes
 #endif
 #if TEMP_COMPENSATE_OPTION
-	/*    */ { 0,			  0,			 0,			      255			       },//!< offset to roomtemp 1=0,1°C, binary complement for <0
+	/*    */ {                     0,                     0,        0,                       255 }, //!< offset to roomtemp 1=0,1°C, binary complement for <0
 #endif
 #if (RFM == 1)
-	/*    */ { RFM_DEVICE_ADDRESS,	  RFM_DEVICE_ADDRESS,	 0,			      29			       },       //!< RFM_devaddr: HR20's own device address in RFM radio networking.
-	/*    */ { SECURITY_KEY_0,	  SECURITY_KEY_0,	 0x00,			      0xff			       },       //!< security_key[0] for encrypted radio messasges
-	/*    */ { SECURITY_KEY_1,	  SECURITY_KEY_1,	 0x00,			      0xff			       },       //!< security_key[1] for encrypted radio messasges
-	/*    */ { SECURITY_KEY_2,	  SECURITY_KEY_2,	 0x00,			      0xff			       },       //!< security_key[2] for encrypted radio messasges
-	/*    */ { SECURITY_KEY_3,	  SECURITY_KEY_3,	 0x00,			      0xff			       },       //!< security_key[3] for encrypted radio messasges
-	/*    */ { SECURITY_KEY_4,	  SECURITY_KEY_4,	 0x00,			      0xff			       },       //!< security_key[4] for encrypted radio messasges
-	/*    */ { SECURITY_KEY_5,	  SECURITY_KEY_5,	 0x00,			      0xff			       },       //!< security_key[5] for encrypted radio messasges
-	/*    */ { SECURITY_KEY_6,	  SECURITY_KEY_6,	 0x00,			      0xff			       },       //!< security_key[6] for encrypted radio messasges
-	/*    */ { SECURITY_KEY_7,	  SECURITY_KEY_7,	 0x00,			      0xff			       },       //!< security_key[7] for encrypted radio messasges
-#if (RFM_TUNING > 0)
-	/*    */ { 0,			  0,			 0x00,			      0xff			       },       //!< RFM12 Frequency adjustment, 2's complement
-	/*    */ { RFM_TUNING_MODE,	  0,			 0x00,			      0x01			       },       //!< RFM12 tuning mode, 0 = tuning mode off (narrow, high data rate), 1 = tuning mode on (wide, low data rate)
-#endif
+	/*    */ {    RFM_DEVICE_ADDRESS,    RFM_DEVICE_ADDRESS,        0,                        29 }, //!< RFM_devaddr: HR20's own device address in RFM radio networking.
+	/*    */ {        SECURITY_KEY_0,        SECURITY_KEY_0,     0x00,                      0xff }, //!< security_key[0] for encrypted radio messasges
+	/*    */ {        SECURITY_KEY_1,        SECURITY_KEY_1,     0x00,                      0xff }, //!< security_key[1] for encrypted radio messasges
+	/*    */ {        SECURITY_KEY_2,        SECURITY_KEY_2,     0x00,                      0xff }, //!< security_key[2] for encrypted radio messasges
+	/*    */ {        SECURITY_KEY_3,        SECURITY_KEY_3,     0x00,                      0xff }, //!< security_key[3] for encrypted radio messasges
+	/*    */ {        SECURITY_KEY_4,        SECURITY_KEY_4,     0x00,                      0xff }, //!< security_key[4] for encrypted radio messasges
+	/*    */ {        SECURITY_KEY_5,        SECURITY_KEY_5,     0x00,                      0xff }, //!< security_key[5] for encrypted radio messasges
+	/*    */ {        SECURITY_KEY_6,        SECURITY_KEY_6,     0x00,                      0xff }, //!< security_key[6] for encrypted radio messasges
+	/*    */ {        SECURITY_KEY_7,        SECURITY_KEY_7,     0x00,                      0xff }, //!< security_key[7] for encrypted radio messasges
+ #if (RFM_TUNING > 0)
+	/*    */ {                     0,                     0,     0x00,                      0xff }, //!< RFM12 Frequency adjustment, 2's complement
+	/*    */ {       RFM_TUNING_MODE,                     0,     0x00,                      0x01 }, //!< RFM12 tuning mode, 0 = tuning mode off (narrow, high data rate),
+	//                                                                                                                      1 = tuning mode on (wide, low data rate)
+ #endif
 #endif
 };
 

--- a/src/lcd.c
+++ b/src/lcd.c
@@ -137,76 +137,76 @@ const uint8_t LCD_CharTablePrgMem[] PROGMEM =
 // Look-up chars table for LCD strings (universal/numbers)
 const uint8_t LCD_StringTable[][4] PROGMEM =
 {
-	{ 32, 1,   22,	7   },  //!<  " 1-7"
-	{ 32, 22,  1,	22  },  //!<  " -1-" MO
-	{ 32, 22,  2,	22  },  //!<  " -2-" TU
-	{ 32, 22,  3,	22  },  //!<  " -3-" WE
-	{ 32, 22,  4,	22  },  //!<  " -4-" TH
-	{ 32, 22,  5,	22  },  //!<  " -5-" FR
-	{ 32, 22,  6,	22  },  //!<  " -6-" SA
-	{ 32, 22,  7,	22  },  //!<  " -7-" SU
-	{ 11, 1,   31,	36  },  //!<  "b1oc"    LCD_STRING_bloc
-	{ 22, 22,  22,	22  },  //!<  "----"    LCD_STRING_4xminus
-	{ 32, 22,  12,	22  },  //!<  " -C-"    LCD_STRING_minusCminus
-	{ 32, 14,  28,	28  },  //!<  " Err"    LCD_STRING_Err
-	{ 0,  15,  15,	32  },  //!<  "OFF "    LCD_STRING_OFF
-	{ 0,  29,  32,	32  },  //!<  "On  "    LCD_STRING_On
-	{ 0,  18,  14,	29  },  //!<  "OPEn"    LCD_STRING_OPEn
-	{ 11, 10,  38,	38  },  //!<  "BAtt"    LCD_STRING_BAtt
-	{ 32, 14,  2,	32  },  //!<  " E2 "    LCD_STRING_E2
-	{ 32, 14,  3,	32  },  //!<  " E3 "    LCD_STRING_E3
-	{ 32, 14,  4,	32  },  //!<  " E4 "    LCD_STRING_E4
-	{ 14, 14,  18,	28  },  //!<  "EEPr"    LCD_STRING_EEPr
+	{ 32, 1,   22,  7   },  //!<  " 1-7"
+	{ 32, 22,  1,   22  },  //!<  " -1-" MO
+	{ 32, 22,  2,   22  },  //!<  " -2-" TU
+	{ 32, 22,  3,   22  },  //!<  " -3-" WE
+	{ 32, 22,  4,   22  },  //!<  " -4-" TH
+	{ 32, 22,  5,   22  },  //!<  " -5-" FR
+	{ 32, 22,  6,   22  },  //!<  " -6-" SA
+	{ 32, 22,  7,   22  },  //!<  " -7-" SU
+	{ 11, 1,   31,  36  },  //!<  "b1oc"    LCD_STRING_bloc
+	{ 22, 22,  22,  22  },  //!<  "----"    LCD_STRING_4xminus
+	{ 32, 22,  12,  22  },  //!<  " -C-"    LCD_STRING_minusCminus
+	{ 32, 14,  28,  28  },  //!<  " Err"    LCD_STRING_Err
+	{ 0,  15,  15,  32  },  //!<  "OFF "    LCD_STRING_OFF
+	{ 0,  29,  32,  32  },  //!<  "On  "    LCD_STRING_On
+	{ 0,  18,  14,  29  },  //!<  "OPEn"    LCD_STRING_OPEn
+	{ 11, 10,  38,  38  },  //!<  "BAtt"    LCD_STRING_BAtt
+	{ 32, 14,  2,   32  },  //!<  " E2 "    LCD_STRING_E2
+	{ 32, 14,  3,   32  },  //!<  " E3 "    LCD_STRING_E3
+	{ 32, 14,  4,   32  },  //!<  " E4 "    LCD_STRING_E4
+	{ 14, 14,  18,  28  },  //!<  "EEPr"    LCD_STRING_EEPr
 };
 #elif LANG == LANG_de
 // Look-up chars table for LCD strings (german)
 const uint8_t LCD_StringTable[][4] PROGMEM =
 {
-	{ 32, 1,   22,	7   },  //!<  " 1-7"
-	{ 33, 34,  31,	32  },  //!<  Montag:     'rno '
-	{ 32, 13,  30,	32  },  //!<  Dienstag:   ' di '
-	{ 33, 34,  30,	32  },  //!<  Mittwoch:   'rni '
-	{ 32, 13,  31,	32  },  //!<  Donnerstag: ' do '
-	{ 32, 15,  28,	32  },  //!<  Freitag:    ' Fr '
-	{ 32, 5,   10,	32  },  //!<  Samstag:    ' SA '
-	{ 32, 5,   31,	32  },  //!<  Sonntag:    ' So '
-	{ 11, 1,   31,	36  },  //!<  "b1oc"    LCD_STRING_bloc
-	{ 22, 22,  22,	22  },  //!<  "----"    LCD_STRING_4xminus
-	{ 32, 22,  12,	22  },  //!<  " -C-"    LCD_STRING_minusCminus
-	{ 32, 14,  28,	28  },  //!<  " Err"    LCD_STRING_Err
-	{ 0,  15,  15,	32  },  //!<  "OFF "    LCD_STRING_OFF
-	{ 0,  29,  32,	32  },  //!<  "On  "    LCD_STRING_On
-	{ 0,  18,  14,	29  },  //!<  "OPEn"    LCD_STRING_OPEn
-	{ 11, 10,  38,	38  },  //!<  "BAtt"    LCD_STRING_BAtt
-	{ 32, 14,  2,	32  },  //!<  " E2 "    LCD_STRING_E2
-	{ 32, 14,  3,	32  },  //!<  " E3 "    LCD_STRING_E3
-	{ 32, 14,  4,	32  },  //!<  " E4 "    LCD_STRING_E4
-	{ 14, 14,  18,	28  },  //!<  "EEPr"    LCD_STRING_EEPr
+	{ 32, 1,   22,  7   },  //!<  " 1-7"
+	{ 33, 34,  31,  32  },  //!<  Montag:     'rno '
+	{ 32, 13,  30,  32  },  //!<  Dienstag:   ' di '
+	{ 33, 34,  30,  32  },  //!<  Mittwoch:   'rni '
+	{ 32, 13,  31,  32  },  //!<  Donnerstag: ' do '
+	{ 32, 15,  28,  32  },  //!<  Freitag:    ' Fr '
+	{ 32, 5,   10,  32  },  //!<  Samstag:    ' SA '
+	{ 32, 5,   31,  32  },  //!<  Sonntag:    ' So '
+	{ 11, 1,   31,  36  },  //!<  "b1oc"    LCD_STRING_bloc
+	{ 22, 22,  22,  22  },  //!<  "----"    LCD_STRING_4xminus
+	{ 32, 22,  12,  22  },  //!<  " -C-"    LCD_STRING_minusCminus
+	{ 32, 14,  28,  28  },  //!<  " Err"    LCD_STRING_Err
+	{ 0,  15,  15,  32  },  //!<  "OFF "    LCD_STRING_OFF
+	{ 0,  29,  32,  32  },  //!<  "On  "    LCD_STRING_On
+	{ 0,  18,  14,  29  },  //!<  "OPEn"    LCD_STRING_OPEn
+	{ 11, 10,  38,  38  },  //!<  "BAtt"    LCD_STRING_BAtt
+	{ 32, 14,  2,   32  },  //!<  " E2 "    LCD_STRING_E2
+	{ 32, 14,  3,   32  },  //!<  " E3 "    LCD_STRING_E3
+	{ 32, 14,  4,   32  },  //!<  " E4 "    LCD_STRING_E4
+	{ 14, 14,  18,  28  },  //!<  "EEPr"    LCD_STRING_EEPr
 };
 #elif LANG == LANG_cs
 // Look-up chars table for LCD strings (czech)
 const uint8_t LCD_StringTable[][4] PROGMEM =
 {
-	{ 32, 1,   22,	7   },  //!<  " 1-7"
-	{ 32, 18,  31,	22  },  //!<  " Po "
-	{ 32, 37,  38,	22  },  //!<  " Ut "
-	{ 32, 5,   38,	22  },  //!<  " St "
-	{ 32, 12,  38,	22  },  //!<  " Ct "
-	{ 32, 18,  10,	22  },  //!<  " PA "
-	{ 32, 5,   31,	22  },  //!<  " So "
-	{ 32, 29,  14,	22  },  //!<  " nE "
-	{ 11, 1,   31,	36  },  //!<  "b1oc"    LCD_STRING_bloc
-	{ 22, 22,  22,	22  },  //!<  "----"    LCD_STRING_4xminus
-	{ 32, 22,  12,	22  },  //!<  " -C-"    LCD_STRING_minusCminus
-	{ 32, 14,  28,	28  },  //!<  " Err"    LCD_STRING_Err
-	{ 0,  15,  15,	32  },  //!<  "OFF "    LCD_STRING_OFF
-	{ 0,  29,  32,	32  },  //!<  "On  "    LCD_STRING_On
-	{ 0,  18,  14,	29  },  //!<  "OPEn"    LCD_STRING_OPEn
-	{ 11, 10,  38,	38  },  //!<  "BAtt"    LCD_STRING_BAtt
-	{ 32, 14,  2,	32  },  //!<  " E2 "    LCD_STRING_E2
-	{ 32, 14,  3,	32  },  //!<  " E3 "    LCD_STRING_E3
-	{ 32, 14,  4,	32  },  //!<  " E4 "    LCD_STRING_E4
-	{ 14, 14,  18,	28  },  //!<  "EEPr"    LCD_STRING_EEPr
+	{ 32, 1,   22,  7   },  //!<  " 1-7"
+	{ 32, 18,  31,  22  },  //!<  " Po "
+	{ 32, 37,  38,  22  },  //!<  " Ut "
+	{ 32, 5,   38,  22  },  //!<  " St "
+	{ 32, 12,  38,  22  },  //!<  " Ct "
+	{ 32, 18,  10,  22  },  //!<  " PA "
+	{ 32, 5,   31,  22  },  //!<  " So "
+	{ 32, 29,  14,  22  },  //!<  " nE "
+	{ 11, 1,   31,  36  },  //!<  "b1oc"    LCD_STRING_bloc
+	{ 22, 22,  22,  22  },  //!<  "----"    LCD_STRING_4xminus
+	{ 32, 22,  12,  22  },  //!<  " -C-"    LCD_STRING_minusCminus
+	{ 32, 14,  28,  28  },  //!<  " Err"    LCD_STRING_Err
+	{ 0,  15,  15,  32  },  //!<  "OFF "    LCD_STRING_OFF
+	{ 0,  29,  32,  32  },  //!<  "On  "    LCD_STRING_On
+	{ 0,  18,  14,  29  },  //!<  "OPEn"    LCD_STRING_OPEn
+	{ 11, 10,  38,  38  },  //!<  "BAtt"    LCD_STRING_BAtt
+	{ 32, 14,  2,   32  },  //!<  " E2 "    LCD_STRING_E2
+	{ 32, 14,  3,   32  },  //!<  " E3 "    LCD_STRING_E3
+	{ 32, 14,  4,   32  },  //!<  " E4 "    LCD_STRING_E4
+	{ 14, 14,  18,  28  },  //!<  "EEPr"    LCD_STRING_EEPr
 };
 #endif
 

--- a/src/lcd.h
+++ b/src/lcd.h
@@ -38,14 +38,13 @@
 *****************************************************************************/
 
 // Modes for LCD_SetSymbol
-#define LCD_MODE_OFF        0           //!< (0b00) segment off
-#define LCD_MODE_BLINK_1    1           //!< (0b01) segment on during 1. frame (blinking)
-#define LCD_MODE_BLINK_2    2           //!< (0b10) segment on during 2. frame (blinking)
-#define LCD_MODE_ON         3           //!< (0b11) segment permanent on
+#define LCD_MODE_OFF           0        //!< (0b00) segment off
+#define LCD_MODE_BLINK_1       1        //!< (0b01) segment on during 1. frame (blinking)
+#define LCD_MODE_BLINK_2       2        //!< (0b10) segment on during 2. frame (blinking)
+#define LCD_MODE_ON            3        //!< (0b11) segment permanent on
 
 #define LCD_CONTRAST_INITIAL  14        //!< initial LCD contrast (0-15)
-#define LCD_BLINK_FRAMES      12        //!< refreshes for each frame @ 48 frames/s
-//!< 12 refreshes -> 4Hz Blink frequency
+#define LCD_BLINK_FRAMES      12        //!< refreshes for each frame @ 48 frames/s; 12 refreshes -> 4Hz Blink frequency
 #define LCD_BITPLANES          2        //!< \brief two bitplanes for blinking
 
 /*****************************************************************************
@@ -191,8 +190,8 @@ void task_lcd_update(void);
 #define LCD_SEG_SNOW       43   //  7, 4 |  SEG120   |  [5], BIT 4
 #define LCD_SEG_SUN        44   //  7, 5 |  SEG121   |  [5], BIT 5
 //*****************************************************************
-// 10, 0 |  SEG200   |  [6], BIT 0
-// 10, 1 |  SEG201   |  [6], BIT 1
+//                                 10, 0 |  SEG200   |  [6], BIT 0
+//                                 10, 1 |  SEG201   |  [6], BIT 1
 #define LCD_SEG_MANU       50   // 10, 2 |  SEG202   |  [6], BIT 2
 #define LCD_SEG_3E         51   // 10, 3 |  SEG203   |  [6], BIT 3
 #define LCD_SEG_3D         52   // 10, 4 |  SEG204   |  [6], BIT 4
@@ -388,8 +387,8 @@ void task_lcd_update(void);
 #define LCD_SEG_SNOW       44   //  7, 4 |  SEG120   |  [5], BIT 4
 #define LCD_SEG_SUN        45   //  7, 5 |  SEG121   |  [5], BIT 5
 //*****************************************************************
-// 10, 0 |  SEG200   |  [6], BIT 0
-// 10, 1 |  SEG201   |  [6], BIT 1
+//                                 10, 0 |  SEG200   |  [6], BIT 0
+//                                 10, 1 |  SEG201   |  [6], BIT 1
 #define LCD_SEG_MANU       50   // 10, 2 |  SEG202   |  [6], BIT 2
 #define LCD_SEG_3E         51   // 10, 3 |  SEG203   |  [6], BIT 3
 #define LCD_SEG_3D         52   // 10, 4 |  SEG204   |  [6], BIT 4

--- a/src/main.c
+++ b/src/main.c
@@ -386,16 +386,16 @@ int __attribute__ ((noreturn)) main(void)
 #ifdef FUSE_BOOTSZ0
 FUSES =
 {
-	.low		= (uint8_t)(FUSE_CKSEL0 & FUSE_CKSEL2 & FUSE_CKSEL3 & FUSE_SUT0 & FUSE_CKDIV8), //0x62
-	.high		= (uint8_t)(FUSE_BOOTSZ0 & FUSE_BOOTSZ1 & FUSE_EESAVE & FUSE_SPIEN & FUSE_JTAGEN),
-	.extended	= (uint8_t)(FUSE_BODLEVEL0),
+	.low            = (uint8_t)(FUSE_CKSEL0 & FUSE_CKSEL2 & FUSE_CKSEL3 & FUSE_SUT0 & FUSE_CKDIV8), //0x62
+	.high           = (uint8_t)(FUSE_BOOTSZ0 & FUSE_BOOTSZ1 & FUSE_EESAVE & FUSE_SPIEN & FUSE_JTAGEN),
+	.extended       = (uint8_t)(FUSE_BODLEVEL0),
 };
 #else
 FUSES =
 {
-	.low		= (uint8_t)(CKSEL0 & CKSEL2 & CKSEL3 & SUT0 & CKDIV8), //0x62
-	.high		= (uint8_t)(BOOTSZ0 & BOOTSZ1 & EESAVE & SPIEN & JTAGEN),
-	.extended	= (uint8_t)(BODLEVEL0),
+	.low            = (uint8_t)(CKSEL0 & CKSEL2 & CKSEL3 & SUT0 & CKDIV8), //0x62
+	.high           = (uint8_t)(BOOTSZ0 & BOOTSZ1 & EESAVE & SPIEN & JTAGEN),
+	.extended       = (uint8_t)(BODLEVEL0),
 };
 #endif
 

--- a/uncrustify.conf
+++ b/uncrustify.conf
@@ -2160,7 +2160,7 @@ align_assign_decl_func          = 0        # unsigned number
 # The span for aligning on '=' in enums.
 #
 # 0 = Don't align (default).
-align_enum_equ_span             = 4        # unsigned number
+align_enum_equ_span             = 0        # unsigned number
 
 # The threshold for aligning on '=' in enums.
 # Use a negative number for absolute thresholds.
@@ -2199,7 +2199,7 @@ align_var_struct_gap            = 0        # unsigned number
 # The span for aligning struct initializer values.
 #
 # 0 = Don't align (default).
-align_struct_init_span          = 3        # unsigned number
+align_struct_init_span          = 0        # unsigned number
 
 # The span for aligning single-line typedefs.
 #


### PR DESCRIPTION
I have cleaned up some of the problematic formatting, turns out they were just remains of some of the earlier steps, as uncrustify was happy even after these manual changes. But during that, I found that running 'make beauty' adds some spaces to initialized structures on every run. Not nice. For now, I have removed the alignment span, seems to fix this. Feel free to find better solution :-).
Please check this and if it looks OK to you, merge it. I will then merge your whole PR.